### PR TITLE
Add disconnected event code

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -11,14 +11,14 @@ export interface CommonDeviceEvent<
 
 // Devices
 export type DeviceConnectedEvent = CommonDeviceEvent<"device.connected">
-export type DeviceDisconnectEvent = CommonDeviceEvent<"device.disconnected">
-export type DeviceTamperEvent = CommonDeviceEvent<"device.tampered">
-export type DeviceLowBatteryEvent = CommonDeviceEvent<
-  "device.low_battery",
+export type DeviceDisconnectEvent = CommonDeviceEvent<
+  "device.disconnected",
   {
-    code: "hub_disconnected" | "device_disconnected"
+    error_code: "hub_disconnected" | "device_disconnected"
   }
 >
+export type DeviceTamperEvent = CommonDeviceEvent<"device.tampered">
+export type DeviceLowBatteryEvent = CommonDeviceEvent<"device.low_battery">
 
 // Access codes
 export type CreateAccessCodeEvent = CommonDeviceEvent<

--- a/src/events.ts
+++ b/src/events.ts
@@ -13,7 +13,12 @@ export interface CommonDeviceEvent<
 export type DeviceConnectedEvent = CommonDeviceEvent<"device.connected">
 export type DeviceDisconnectEvent = CommonDeviceEvent<"device.disconnected">
 export type DeviceTamperEvent = CommonDeviceEvent<"device.tampered">
-export type DeviceLowBatteryEvent = CommonDeviceEvent<"device.low_battery">
+export type DeviceLowBatteryEvent = CommonDeviceEvent<
+  "device.low_battery",
+  {
+    code: "hub_disconnected" | "device_disconnected"
+  }
+>
 
 // Access codes
 export type CreateAccessCodeEvent = CommonDeviceEvent<


### PR DESCRIPTION
To allow API consumers to differentiate between hub or device disconnection events